### PR TITLE
Fix matplotlib installation step

### DIFF
--- a/INSTALL.py
+++ b/INSTALL.py
@@ -671,7 +671,7 @@ if "optional" in enabledWorkflows or manual:
              os.system("rm -rf phylosift.tar.bz2")
              os.system("mv phylosift_20130829 phylosift")
 
-          if not os.path.exists("./phylosift/legacy/version.pm"):
+          if not os.path.exists("./phylosift/lib/version.pm"):
              #phylosift needs version but doesn't include it
              os.system("curl -L http://www.cpan.org/authors/id/J/JP/JPEACOCK/version-0.9903.tar.gz -o version.tar.gz")
              os.system("tar xvzf version.tar.gz")


### PR DESCRIPTION
Hello.
As we discussed by email, here is my (first) pull request which fix crash caused by matplotlib installation step.
Calling "matplotlib.__version__" if matplotlib is not installed makes the script crash.
Best.
