### PR TITLE
Fix error that occurs processing fasta files in certain situations. Sinc...

### DIFF
--- a/src/generic.py
+++ b/src/generic.py
@@ -246,7 +246,7 @@ class GenericProgram:
                break
 
             run_process(_settings, "head -n 4 %s/Preprocess/out/lib%d.%s > %s/Preprocess/out/tmp.%s"%(_settings.rundir, lib.id, suffix, _settings.rundir, suffix), STEP_NAMES.reverse_mapping[self.stepName].title())
-            libReadLen = getCommandOutput("java -cp %s SizeFasta %s/Preprocess/out/tmp.%s |awk '{print $NF}'"%(_settings.METAMOS_JAVA, _settings.rundir, suffix), False)
+            libReadLen = getCommandOutput("java -cp %s SizeFasta %s/Preprocess/out/tmp.%s | head -1 | awk '{print $NF}'"%(_settings.METAMOS_JAVA, _settings.rundir, suffix), False)
             run_process(_settings, "rm -f %s/Preprocess/out/tmp.%s"%(_settings.rundir, suffix), STEP_NAMES.reverse_mapping[self.stepName].title())
             if (int(libReadLen) < self.readLen):
                self.readLen = int(libReadLen)


### PR DESCRIPTION
I was seeing the following error. (see below)
Since the code grabs 4 lines, it is possible to end up with two sequences when working with fasta files. 

Completed Task = assemble.SplitAssemblers
**\* metAMOS running command: head -n 4 /mnt/galaxyData/analysis/4_CCGTCC/Preprocess/out/lib1.fastq > /mnt/galaxyData/analysis/4_CCGTCC/Preprocess/out/tmp.fastq

**\* metAMOS running command: rm -f /mnt/galaxyData/analysis/4_CCGTCC/Preprocess/out/tmp.fastq

**\* metAMOS running command: /mnt/galaxy/metamos/metAMOS-1.5rc3/Utilities/cpp/Linux-x86_64/abyss/bin/abyss-pe k=47 name=abyss.47 lib='lib1' mp='' np=32  lib1='/mnt/galaxyData/analysis/4_CCGTCC/Preprocess/out/lib1.1.fastq /mnt/galaxyData/analysis/4_CCGTCC/Preprocess/out/lib1.2.fastq'

**\* metAMOS running command: unlink /mnt/galaxyData/analysis/4_CCGTCC/Assemble/out/abyss.47.asm.contig

**\* metAMOS running command: ln /mnt/galaxyData/analysis/4_CCGTCC/Assemble/out/abyss.47-contigs.fa /mnt/galaxyData/analysis/4_CCGTCC/Assemble/out/abyss.47.asm.contig

**\* metAMOS running command: ln /mnt/galaxyData/analysis/4_CCGTCC/Assemble/out/abyss.47-contigs.fa /mnt/galaxyData/analysis/4_CCGTCC/Assemble/out/abyss.47.linearize.scaffolds.final

```
Job = [abyss.47.run -> abyss.47.asm.contig] completed
```

**\* metAMOS running command: head -n 4 /mnt/galaxyData/analysis/4_CCGTCC/Preprocess/out/lib1.fasta > /mnt/galaxyData/analysis/4_CCGTCC/Preprocess/out/tmp.fasta

**\* metAMOS running command: rm -f /mnt/galaxyData/analysis/4_CCGTCC/Preprocess/out/tmp.fasta

Oops, MetAMOS finished with errors! see text in red above for details.
Traceback (most recent call last):
  File "../runPipeline", line 984, in <module>
    verbose = 1)
  File "/usr/local/lib/python2.7/dist-packages/ruffus/task.py", line 2680, in pipeline_run
    raise errt
RethrownJobError:

```
Exceptions running jobs for

'def assemble.Assemble(...):'

Original exception:

Exception #1
exceptions.ValueError(invalid literal for int() with base 10: '50\n50'):
for assemble.Assemble.Job = [idba-ud.47.run -> idba-ud.47.asm.contig]

Traceback (most recent call last):
  File "/usr/local/lib/python2.7/dist-packages/ruffus/task.py", line 517, in run_pooled_job_without_exceptions
    return_value =  job_wrapper(param, user_defined_work_func, register_cleanup, touch_files_only)
  File "/usr/local/lib/python2.7/dist-packages/ruffus/task.py", line 447, in job_wrapper_io_files
    ret_val = user_defined_work_func(*param)
  File "/mnt/galaxy/metamos/metAMOS-1.5rc3/src/assemble.py", line 537, in Assemble
    generic.execute(STEP_NAMES.ASSEMBLE, asmName.lower(), _settings)
  File "/mnt/galaxy/metamos/metAMOS-1.5rc3/src/generic.py", line 493, in execute
    return dispatch.execute()
  File "/mnt/galaxy/metamos/metAMOS-1.5rc3/src/generic.py", line 342, in execute
    (havePE, haveMP, offset, input, pelist, mplist, techParams) = self.getLibInput()
  File "/mnt/galaxy/metamos/metAMOS-1.5rc3/src/generic.py", line 251, in getLibInput
    if (int(libReadLen) < self.readLen):
ValueError: invalid literal for int() with base 10: '50\n50'
```
