### PR TITLE
fixes installation help

### DIFF
--- a/docs/content/installation.rst
+++ b/docs/content/installation.rst
@@ -114,7 +114,7 @@ Also, you can run:
 
 .. code-block:: bash
 
-    $ python INSTALL.py -h
+    $ python INSTALL.py help
 
 to get a listing of available workflows and programs. You can specify either
 workflows or programs as arguments to INSTALL.py. For example, to install the


### PR DESCRIPTION
-   with `-h` you get

    ```console
    $ python INSTALL.py -h
    <<Welcome to metAMOS install>>
    Unknown program or workflow -h specified.
    Available workflows: core imetamos optional deprecated
    Available packages: pysam
    ...
    ```

-   with `help` you get

    ```console
    $ python INSTALL.py help
    <<Welcome to metAMOS install>>
    Available workflows: core imetamos optional deprecated
    Available packages: pysam
    ...
    ```